### PR TITLE
Configure etcd authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,29 @@ Use [cloud-init][] to configure your cloud instance.
     ```console
     $ cd /extas/setup
     $ sudo ./setup-bootserver init RACK1 RACK2 RACK3 [RACK...]
+    sabakan etcd password: xxxx
+    ```
+
+    As shown, `setup-bootserver` asks a password.  This will be used for etcd
+    authentication.  The username of etcd is fixed as `sabakan`.  If you want
+    to enable etcd authentication, create `sabakan` user as follows:
+
+    ```console
+    $ etcdctl user add root
+    Password: xxxx
+    $ etcdctl user add sabakan
+    Password: (the password given to setup-bootserver)
+    $ etcdctl role add sabakan
+    $ etcdctl role grant-permission sabakan --prefix=true readwrite /sabakan/
+    $ etcdctl user grant-role sabakan sabakan
+    $ etcdctl auth enable
     ```
 
 ### Notes
 
 After setup, the system is configured as follows.
 
+* etcd authentication is *not* enabled.
 * Running `systemd-networkd` instead of `netplan.io`.  `netplan.io` is purged.
 * Running `rkt` containers as systemd services.  Use `sudo rkt list` to get the list of them.
 * The rack number of the server is stored in `/etc/neco/rack` file.

--- a/README.md
+++ b/README.md
@@ -84,23 +84,23 @@ Use [cloud-init][] to configure your cloud instance.
     ```console
     $ cd /extas/setup
     $ sudo ./setup-bootserver init RACK1 RACK2 RACK3 [RACK...]
-    sabakan etcd password: xxxx
+    sabakan etcd password: yyyy
     ```
 
     As shown, `setup-bootserver` asks a password.  This will be used for etcd
     authentication.  The username of etcd is fixed as `sabakan`.  If you want
-    to enable etcd authentication, create `sabakan` user as follows:
+    to enable etcd authentication, run `setup-etcd-user` script as follows:
 
     ```console
-    $ etcdctl user add root
-    Password: xxxx
-    $ etcdctl user add sabakan
-    Password: (the password given to setup-bootserver)
-    $ etcdctl role add sabakan
-    $ etcdctl role grant-permission sabakan --prefix=true readwrite /sabakan/
-    $ etcdctl user grant-role sabakan sabakan
-    $ etcdctl auth enable
+    $ cd /extras/setup
+    $ sudo ./setup-etcd-user
+    root password: xxxx
+    sabakan password: yyyy
+    backup password: zzzz
     ```
+
+    Note that `sabakan password` must be the same as the password given to
+    `setup-bootserver`.  Be warned that these passwords should be kept securely.
 
 ### Notes
 

--- a/setup/chrony-wait
+++ b/setup/chrony-wait
@@ -1,5 +1,10 @@
 #!/bin/sh -e
 
-sleep 1
-uuid=$(rkt list --no-legend | awk '{if ($4 == "running" && $2 == "chrony") print $1}')
+while true; do
+    uuid=$(rkt list --no-legend | awk '{if ($4 == "running" && $2 == "chrony") print $1}')
+    if [ "$uuid" != "" ]; then
+        break
+    fi
+done
+
 exec rkt enter --app=chrony $uuid chronyc waitsync 600 0.1 0.0 1

--- a/setup/sabakan-local.service
+++ b/setup/sabakan-local.service
@@ -2,6 +2,7 @@
 Description=Local Sabakan server
 AssertPathExists=/usr/local/etc/sabakan.yml
 Conflicts=sabakan.service
+After=sabakan.service
 
 [Service]
 Type=simple

--- a/setup/sabakan.yml.template
+++ b/setup/sabakan.yml.template
@@ -1,3 +1,5 @@
 advertise-url: ${advertise_url}
 dhcp-bind: 0.0.0.0:67
 etcd-servers: ${etcd_servers}
+etcd-username: sabakan
+etcd-password: ${etcd_password}

--- a/setup/setup-bootserver
+++ b/setup/setup-bootserver
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import argparse
+import getpass
 import ipaddress
 import json
 import os
@@ -85,7 +86,7 @@ def setup_etcd(lrn: int, racks: [int]):
     print("Initialized etcd")
 
 
-def setup_sabakan(lrn: int, racks: [int]):
+def setup_sabakan(lrn: int, racks: [int], password: str):
     prepare_sabakan_data_dir()
     with open(SABAKANCONF_TMPL) as f:
         templ = string.Template(f.read())
@@ -94,6 +95,7 @@ def setup_sabakan(lrn: int, racks: [int]):
     data = templ.substitute(
         advertise_url=advertise_url,
         etcd_servers=json.dumps(etcd_servers),
+        etcd_password=password,
     )
     dump_file(SABAKANCONF, data)
 
@@ -105,22 +107,28 @@ def setup_sabakan(lrn: int, racks: [int]):
     print("Initialized sabakan")
 
 
-def init(racks: [int]):
+def init(racks: [int], password: str):
     lrn = my_lrn()
 
     if lrn in racks:
         setup_etcd(lrn, racks)
 
-    setup_sabakan(lrn, racks)
+    setup_sabakan(lrn, racks, password)
 
 
 def main():
     p = argparse.ArgumentParser()
+    p.add_argument('--sabakan-etcd-password', dest='password',
+                   help='etcd user password (only for GCP env)')
     p.add_argument('action', choices=['init'])
     p.add_argument('racks', metavar='RACK_NUMBERS', type=int, nargs='+',
                    help='logical rack numbers where etcd should run')
 
     ns = p.parse_args()
+
+    password = ns.password
+    if password is None:
+        password = getpass.getpass('sabakan etcd password: ')
 
     if ns.action == 'init':
         if len(ns.racks) < 3:
@@ -128,7 +136,7 @@ def main():
         for lrn in ns.racks:
             if lrn < 0:
                 sys.exit('invalid rack number: {}'.format(lrn))
-        init(ns.racks)
+        init(ns.racks, password)
 
 
 if __name__ == '__main__':

--- a/setup/setup-etcd-user
+++ b/setup/setup-etcd-user
@@ -1,0 +1,110 @@
+#!/usr/bin/python3
+
+import argparse
+import getpass
+import json
+import subprocess
+from subprocess import DEVNULL, PIPE
+import time
+
+
+def pod_uuid(app: str) ->str:
+    while True:
+        p = subprocess.run(['rkt', 'list', '--format=json'], stdout=PIPE, check=True)
+        j = json.loads(p.stdout)
+        # for unknown reason, "rkt list" sometimes returns null...
+        if j is not None:
+            break
+        time.sleep(1)
+
+    for d in j:
+        if 'app_names' not in d:
+            continue
+        if app not in d['app_names']:
+            continue
+        if d['state'] != 'running':
+            continue
+        return d['name']
+    raise RuntimeError('no running {} pod'.format(app))
+
+
+def wait_etcd(etcdctl):
+    for i in range(300):
+        if etcdctl('get', '/').returncode == 0:
+            return
+        time.sleep(1)
+    raise RuntimeError('no response from etcd')
+
+
+def user_exists(etcdctl, user: str) ->bool:
+    return etcdctl('user', 'get', user, stdout=DEVNULL, stderr=DEVNULL).returncode == 0
+
+
+def role_exists(etcdctl, role: str) ->bool:
+    return etcdctl('role', 'get', role, stdout=DEVNULL, stderr=DEVNULL).returncode == 0
+
+
+def configure_root(etcdctl, passwd: str):
+    if user_exists(etcdctl, 'root'):
+        return
+    etcdctl('user', 'add', '--interactive=false', 'root', input=passwd, check=True)
+    print('added root user.')
+
+
+def configure_sabakan(etcdctl, passwd):
+    if user_exists(etcdctl, 'sabakan'):
+        return
+    if not role_exists(etcdctl, 'sabakan'):
+        etcdctl('role', 'add', 'sabakan', check=True)
+        etcdctl('role', 'grant-permission', 'sabakan',
+                '--prefix=true', 'readwrite', '/sabakan/', check=True)
+    if passwd is None:
+        passwd = getpass.getpass('sabakan password: ')
+    etcdctl('user', 'add', '--interactive=false', 'sabakan', input=passwd, check=True)
+    etcdctl('user', 'grant-role', 'sabakan', 'sabakan', check=True)
+    print('added sabakan user.')
+
+
+def configure_backup(etcdctl, passwd):
+    if user_exists(etcdctl, 'backup'):
+        return
+    if passwd is None:
+        passwd = getpass.getpass('backup password: ')
+    etcdctl('user', 'add', '--interactive=false', 'backup', input=passwd, check=True)
+    etcdctl('user', 'grant-role', 'backup', 'root')
+    print('added backup user.')
+
+
+def main():
+    p = argparse.ArgumentParser(description='setup etcd user and enable authentication')
+    p.add_argument('--root-password', dest='root_passwd',
+                   help='etcd root user password (only for GCP env)')
+    p.add_argument('--sabakan-password', dest='saba_passwd',
+                   help='etcd sabakan user password (only for GCP env)')
+    p.add_argument('--backup-password', dest='backup_passwd',
+                   help='etcd backup user password (only for GCP env)')
+    ns = p.parse_args()
+
+    root_passwd = ns.root_passwd
+    if root_passwd is None:
+        root_passwd = getpass.getpass('root password: ')
+
+    uuid = pod_uuid('etcd')
+    def etcdctl(*args, **kwargs) ->subprocess.CompletedProcess:
+        cmd = ['rkt', 'enter', '--app=etcd', uuid,
+               'etcdctl', '--user=root:'+ root_passwd, *args]
+        if 'input' in kwargs and 'encoding' not in kwargs:
+            kwargs['encoding'] = 'utf-8'
+        return subprocess.run(cmd, **kwargs)
+
+    wait_etcd(etcdctl)
+    configure_root(etcdctl, root_passwd)
+    configure_sabakan(etcdctl, ns.saba_passwd)
+    configure_backup(etcdctl, ns.backup_passwd)
+
+    etcdctl('auth', 'enable', check=True)
+    print('enabled etcd authentication.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The main change of this pull request is to add `setup-etcd-user` script.
It adds users and roles to etcd and enables authentication.

`setup-bootserver` is changed to ask password of etcd user for sabakan.