### PR TITLE
[setup-bootserver] deploy etcdpasswd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .#*
 \#*#
 /build
+/etcdpasswd

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Build
     This file will be read by `setup-neco-network`.
     An example of the file is available at `setup/cluster.json.example`.
 
+1. Prepare [etcdpasswd][] repository.
+
+    You may create a symlink to an existing `etcdpasswd` directory, or
+    clone it as follows:
+
+    ```console
+    $ git clone https://github.com/cybozu-go/etcdpasswd
+    ```
+
 1. Run `make` to see available build options.
 1. Run `make setup`.  This is a one-time procedure.
 1. Run `make all` to build everything.
@@ -76,7 +85,9 @@ Use [cloud-init][] to configure your cloud instance.
 3. Configure and run `sabakan` and `etcd`
 
     Run `setup-bootserver` script as follows.
-    This configures [`sabakan`][sabakan], a distributed network boot service.
+    This configures [`sabakan`][sabakan], a distributed network boot service,
+    and [`etcdpasswd`][etcdpasswd], a distributed user/group management service.
+
     Additionally, the script also configures `etcd` and `etcd-backup` if the
     rack matches the given rack number on the command-line.
 
@@ -85,12 +96,13 @@ Use [cloud-init][] to configure your cloud instance.
     $ sudo ./setup-bootserver init RACK1 RACK2 RACK3 [RACK...]
     sabakan etcd password: yyyy
     backup etcd password: zzzz
+    etcdpasswd etcd password: qqqq
     ```
 
     As shown, `setup-bootserver` asks passwords.  This will be used for etcd
-    authentication.  The first password is for `sabakan` user of etcd, second
-    is for `backup` user.  If you want to enable etcd authentication, run
-    `setup-etcd-user` script as follows:
+    authentication.  The first password is for `sabakan` user of etcd, the
+    second is for `backup`, and the third is for `etcdpasswd`.  If you want
+    to enable etcd authentication, run `setup-etcd-user` script as follows:
 
     ```console
     $ cd /extras/setup
@@ -98,10 +110,12 @@ Use [cloud-init][] to configure your cloud instance.
     root password: xxxx
     sabakan password: yyyy
     backup password: zzzz
+    etcdpasswd password: qqqq
     ```
 
-    Note that `sabakan password` must be the same as the password given to
-    `setup-bootserver`.  Be warned that these passwords should be kept securely.
+    Note that passwords given to `setup-etcd-user` should be the same as
+    those given to `setup-bootserver`.
+    Be warned that these passwords should be kept securely.
 
 ### Notes
 
@@ -111,6 +125,7 @@ After setup, the system is configured as follows.
 * Running `systemd-networkd` instead of `netplan.io`.  `netplan.io` is purged.
 * Running `rkt` containers as systemd services.  Use `sudo rkt list` to get the list of them.
 * `etcd-backup.service` is kicked by systemd.timer once an hour. It gets a snapshot from etcd.
+* Running `ep-agent.service` to synchronize users and groups.
 * The rack number of the server is stored in `/etc/neco/rack` file.
 * The cluster ID of the server is stored in `/etc/neco/cluster` file.
 
@@ -123,4 +138,5 @@ License
 [placemat-menu]: https://github.com/cybozu-go/placemat-menu
 [cloud-init]: https://cloudinit.readthedocs.io/
 [sabakan]: https://github.com/cybozu-go/sabakan
+[etcdpasswd]: https://github.com/cybozu-go/etcdpasswd
 [MIT]: https://opensource.org/licenses/MIT

--- a/setup/setup-bootserver
+++ b/setup/setup-bootserver
@@ -2,6 +2,7 @@
 
 import argparse
 import getpass
+import glob
 import ipaddress
 import json
 import os
@@ -20,6 +21,7 @@ ETCDCONF_TMPL = 'etcd.conf.yml.template'
 ETCDCONF = '/etc/etcd/etcd.conf.yml'
 SABAKANCONF_TMPL = 'sabakan.yml.template'
 SABAKANCONF = '/usr/local/etc/sabakan.yml'
+ETCDPASSWDCONF = '/etc/etcdpasswd.yml'
 RACK_INFORMATION = '/etc/neco/rack'
 
 
@@ -123,22 +125,50 @@ def setup_etcd_backup(password: str):
     print("Initialized etcd-backup")
 
 
-def init(racks: [int], saba_passwd: str, backup_passwd: str):
+def setup_etcdpasswd(racks: [int], password: str):
+    etcd_servers = ['http://{!s}:2379'.format(boot_node0_ip(lrn)) for lrn in racks]
+    tmpl = string.Template('''servers: ${etcd_servers}
+username: etcdpasswd
+password: ${password}
+''')
+    data = tmpl.substitute(
+        etcd_servers=json.dumps(etcd_servers),
+        password=password,
+    )
+    dump_file(ETCDPASSWDCONF, data)
+
+    deb = glob.glob('/extras/etcdpasswd*.deb')
+    subprocess.run(['dpkg', '-i', deb[0]], check=True)
+
+    shutil.copyfile('/extras/setup/sshd_config', '/etc/ssh/sshd_config')
+    # do not restart ssh.service at this point.
+
+    shutil.copyfile('/extras/setup/sudoers', '/etc/sudoers.d/.cybozu')
+    os.chmod('/etc/sudoers.d/.cybozu', 0o440)
+    os.rename('/etc/sudoers.d/.cybozu', '/etc/sudoers.d/cybozu')
+    print("Initialized etcdpasswd")
+
+
+def init(racks: [int], saba_passwd: str, backup_passwd: str, etcdpasswd_passwd: str):
     lrn = my_lrn()
 
     if lrn in racks:
         setup_etcd(lrn, racks)
         setup_etcd_backup(backup_passwd)
 
+    setup_etcdpasswd(racks, etcdpasswd_passwd)
     setup_sabakan(lrn, racks, saba_passwd)
+    os.sync()
 
 
 def main():
     p = argparse.ArgumentParser()
     p.add_argument('--sabakan-etcd-password', dest='saba_passwd',
                    help='etcd sabakan user password (only for GCP env)')
-    p.add_argument('--etcd-backup-password', dest='backup_passwd',
+    p.add_argument('--backup-etcd-password', dest='backup_passwd',
                    help='etcd backup user password (only for GCP env)')
+    p.add_argument('--etcdpasswd-etcd-password', dest='etcdpasswd_passwd',
+                   help='etcdpasswd user password (only for GCP env)')
     p.add_argument('action', choices=['init'])
     p.add_argument('racks', metavar='RACK_NUMBERS', type=int, nargs='+',
                    help='logical rack numbers where etcd should run')
@@ -153,13 +183,18 @@ def main():
     if backup_passwd is None:
         backup_passwd = getpass.getpass('backup etcd password: ')
 
+    etcdpasswd_passwd = ns.etcdpasswd_passwd
+    if etcdpasswd_passwd is None:
+        etcdpasswd_passwd = getpass.getpass('etcdpasswd etcd password: ')
+
     if ns.action == 'init':
         if len(ns.racks) < 3:
             sys.exit('too few etcd servers')
         for lrn in ns.racks:
             if lrn < 0:
                 sys.exit('invalid rack number: {}'.format(lrn))
-        init(ns.racks, saba_passwd, backup_passwd)
+        init(ns.racks, saba_passwd, backup_passwd, etcdpasswd_passwd)
+        return
 
 
 if __name__ == '__main__':

--- a/setup/setup-etcd-user
+++ b/setup/setup-etcd-user
@@ -75,6 +75,20 @@ def configure_backup(etcdctl, passwd):
     print('added backup user.')
 
 
+def configure_etcdpasswd(etcdctl, passwd):
+    if user_exists(etcdctl, 'etcdpasswd'):
+        return
+    if not role_exists(etcdctl, 'etcdpasswd'):
+        etcdctl('role', 'add', 'etcdpasswd', check=True)
+        etcdctl('role', 'grant-permission', 'etcdpasswd',
+                '--prefix=true', 'readwrite', '/passwd/', check=True)
+    if passwd is None:
+        passwd = getpass.getpass('etcdpasswd password: ')
+    etcdctl('user', 'add', '--interactive=false', 'etcdpasswd', input=passwd, check=True)
+    etcdctl('user', 'grant-role', 'etcdpasswd', 'etcdpasswd', check=True)
+    print('added etcdpasswd user.')
+
+
 def main():
     p = argparse.ArgumentParser(description='setup etcd user and enable authentication')
     p.add_argument('--root-password', dest='root_passwd',
@@ -83,6 +97,8 @@ def main():
                    help='etcd sabakan user password (only for GCP env)')
     p.add_argument('--backup-password', dest='backup_passwd',
                    help='etcd backup user password (only for GCP env)')
+    p.add_argument('--etcdpasswd-password', dest='etcdpasswd_passwd',
+                   help='etcdpasswd user password (only for GCP env)')
     ns = p.parse_args()
 
     root_passwd = ns.root_passwd
@@ -101,6 +117,7 @@ def main():
     configure_root(etcdctl, root_passwd)
     configure_sabakan(etcdctl, ns.saba_passwd)
     configure_backup(etcdctl, ns.backup_passwd)
+    configure_etcdpasswd(etcdctl, ns.etcdpasswd_passwd)
 
     etcdctl('auth', 'enable', check=True)
     print('enabled etcd authentication.')

--- a/setup/sshd_config
+++ b/setup/sshd_config
@@ -1,0 +1,125 @@
+#	$OpenBSD: sshd_config,v 1.101 2017/03/14 07:19:07 djm Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel INFO
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#StrictModes yes
+#MaxAuthTries 6
+#MaxSessions 10
+
+# Cybozu: NecoTask-220
+PubkeyAuthentication yes
+
+# Expect .ssh/authorized_keys2 to be disregarded by default in future.
+# Cybozu: NecoTask-220
+AuthorizedKeysFile	.ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+# Cybozu: NecoTask-220
+PasswordAuthentication no
+#PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+#GSSAPIStrictAcceptorCheck yes
+#GSSAPIKeyExchange no
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+#AllowAgentForwarding yes
+#AllowTcpForwarding yes
+#GatewayPorts no
+X11Forwarding yes
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+PrintMotd no
+#PrintLastLog yes
+#TCPKeepAlive yes
+#UseLogin no
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+#PidFile /var/run/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+# override default of no subsystems
+Subsystem	sftp	/usr/lib/openssh/sftp-server
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#	X11Forwarding no
+#	AllowTcpForwarding no
+#	PermitTTY no
+#	ForceCommand cvs server

--- a/setup/sudoers
+++ b/setup/sudoers
@@ -1,0 +1,1 @@
+%sudo   ALL=(ALL:ALL) NOPASSWD: ALL


### PR DESCRIPTION
Moreover, the script now installs /etc/ssh/sshd_config and
/etc/sudoers.d/cybozu for systems managed by etcdpasswd.

setup-etcd-user also configures etcdpasswd user and its role.