### PR TITLE
Specify sabakan's tag explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ CONTAINERS:=\
 	ubuntu-debug:18.04 \
 	etcd:3.3 \
 	chrony:3.3 \
-	sabakan:0
+	sabakan:0.9-2
 ACI_FILES=$(patsubst %,build/cybozu-%.aci,$(subst :,-,$(CONTAINERS)))
 ARTIFACTS=$(ORIGINAL_ISO_PATH) $(ORIGINAL_CLOUD_PATH) $(RKT_DEB_PATH) $(DOCKER2ACI)
 PREVIEW_IMG=$(BUILD_DIR)/ubuntu.img
@@ -88,7 +88,7 @@ $(DOCKER2ACI):
 	cd $(BUILD_DIR); $(CURL) $(DOCKER2ACI_URL) | tar -x -z -f - --strip-components=1
 
 %.aci: $(DOCKER2ACI)
-	cd $(BUILD_DIR); ./docker2aci $$(echo $@ | sed -r 's,build/cybozu-(.*)-([^-]+).aci,docker://quay.io/cybozu/\1:\2,')
+	cd $(BUILD_DIR); ./docker2aci $$(echo $@ | sed -r 's,build/cybozu-([^-]+)-([0-9.-]+)\.aci,docker://quay.io/cybozu/\1:\2,')
 	chmod 644 $@
 
 $(CUSTOM_ISO_PATH): $(ORIGINAL_ISO_PATH) $(DEBS) $(ACI_FILES) $(CLUSTER_JSON)

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ $(DOCKER2ACI):
 	cd $(BUILD_DIR); $(CURL) $(DOCKER2ACI_URL) | tar -x -z -f - --strip-components=1
 
 %.aci: $(DOCKER2ACI)
-	cd $(BUILD_DIR); ./docker2aci $$(echo $@ | sed -r 's,build/cybozu-([^-]+)-([0-9.-]+)\.aci,docker://quay.io/cybozu/\1:\2,')
+	cd $(BUILD_DIR); ./docker2aci $$(echo $@ | sed -r 's,build/cybozu-([^0-9]+)-([0-9.-]+)\.aci,docker://quay.io/cybozu/\1:\2,')
 	chmod 644 $@
 
 $(CUSTOM_ISO_PATH): $(ORIGINAL_ISO_PATH) $(DEBS) $(ACI_FILES) $(CLUSTER_JSON)

--- a/setup/sabakan.service
+++ b/setup/sabakan.service
@@ -18,7 +18,7 @@ ExecStart=/usr/bin/rkt run \
   --volume data,kind=host,source=/var/lib/sabakan \
   --mount volume=data,target=/var/lib/sabakan \
   --net=host \
-  quay.io/cybozu/sabakan:0 \
+  quay.io/cybozu/sabakan:0.9-2 \
     --name sabakan \
     --readonly-rootfs=true \
     --caps-retain=CAP_NET_BIND_SERVICE \

--- a/setup/setup-bootserver
+++ b/setup/setup-bootserver
@@ -93,12 +93,12 @@ def setup_etcd(lrn: int, racks: [int]):
 def setup_sabakan(lrn: int, racks: [int], password: str):
     subprocess.run([
         "tar", "-C", "/usr/local/bin",
-        "-x", "-f", "/extras/cybozu-sabakan-0.aci",
+        "-x", "-f", "/extras/cybozu-sabakan-0.9-2.aci",
         "--strip-components", "5",
         "rootfs/usr/local/sabakan/bin/sabactl"], check=True)
     subprocess.run([
         "tar", "-C", "/etc/bash_completion.d/",
-        "-x", "-f", "/extras/cybozu-sabakan-0.aci",
+        "-x", "-f", "/extras/cybozu-sabakan-0.9-2.aci",
         "--strip-components", "4", "--transform", "s/sabactl_completion.bash/sabactl/",
         "rootfs/usr/local/sabakan/sabactl_completion.bash"], check=True)
 


### PR DESCRIPTION
In order to deploy sabakan safely, and rebuild when tag is updated.