### PR TITLE
Install wheel before pip3 install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ DOCKER2ACI=$(BUILD_DIR)/docker2aci
 
 PYTHON3_FILES=$(shell find setup/ -type f | xargs awk '/python3/ {print FILENAME} {nextfile}')
 PYTHON3_DEPS:=pylint pycodestyle
-PYLINT3:=pylint
-PYCODESTYLE3:=pycodestyle
+PYLINT3:=$(shell test -f /usr/local/bin/pylint && echo /usr/local/bin/pylint || echo $$HOME/.local/bin/pylint)
+PYCODESTYLE3:=$(shell test -f /usr/local/bin/pycodestyle && echo /usr/local/bin/pycodestyle || echo $$HOME/.local/bin/pycodestyle)
 
 BUILD_DEPS:=xorriso qemu-utils qemu-kvm ovmf curl ca-certificates cloud-image-utils gdisk kpartx python3-pip python3-setuptools
 CONTAINERS:=\
@@ -161,6 +161,8 @@ fullclean: clean
 
 setup:
 	sudo apt-get -y install --no-install-recommends $(BUILD_DEPS)
+	# wheel is required to install pylint for some distributions
+	pip3 install wheel
 	pip3 install $(PYTHON3_DEPS)
 
 .PHONY: help all iso cloud preview-iso preview-cloud lint clean fullclean setup


### PR DESCRIPTION
Plane environment requires "wheel" to install pylint.