### PR TITLE
fix podenter

### DIFF
--- a/setup/podenter
+++ b/setup/podenter
@@ -4,17 +4,14 @@ import argparse
 import json
 import os
 import subprocess
-import time
 
 
 def pod_uuid(app: str) -> str:
-    while True:
-        p = subprocess.run(['rkt', 'list', '--format=json'], stdout=subprocess.PIPE, check=True)
-        j = json.loads(p.stdout)
-        # for unknown reason, "rkt list" sometimes returns null...
-        if j is not None:
-            break
-        time.sleep(1)
+    p = subprocess.run(['rkt', 'list', '--format=json'], stdout=subprocess.PIPE, check=True)
+    j = json.loads(p.stdout)
+    # for unknown reason, "rkt list" sometimes returns null...
+    if j is None:
+        raise RuntimeError('rkt list is empty')
 
     for d in j:
         if 'app_names' not in d:
@@ -31,7 +28,7 @@ def main():
     parser = argparse.ArgumentParser(description='util for entering into rkt pod')
     parser.add_argument('app_name')
     parser.add_argument('--debug', action='store_true', help='enter ubuntu-debug container instead of app_name')
-    parser.add_argument('commands', nargs='*')
+    parser.add_argument('commands', nargs=argparse.REMAINDER)
 
     args = parser.parse_args()
 

--- a/setup/podenter
+++ b/setup/podenter
@@ -9,7 +9,6 @@ import subprocess
 def pod_uuid(app: str) -> str:
     p = subprocess.run(['rkt', 'list', '--format=json'], stdout=subprocess.PIPE, check=True)
     j = json.loads(p.stdout)
-    # for unknown reason, "rkt list" sometimes returns null...
     if j is None:
         raise RuntimeError('rkt list is empty')
 


### PR DESCRIPTION
"setup/podenter"を編集しました。

- ブートサーバーのpodenterでオプションが渡せない
nargsの値を以降の要素すべてを意味する"argparse.REMAINDER"に変更する。

- 無限リトライしてる箇所を落とす
ループを削除し、listが取得できないときは例外を発生させて終了するように変更。
また、この変更によりtimeを使用しなくなったので削除。

の二点を変更しています。