### PR TITLE
Ci img build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,15 @@
 version: 2
 jobs:
   build:
-    docker:
-      - image: quay.io/cybozu/golang:1.10-bionic
+    machine:
+        image: circleci/classic:201708-01
     steps:
       - run: apt-get update
       - run: apt-get install -y --no-install-recommends python3-pip python3-setuptools
       - run: pip3 install pylint pycodestyle
+      - run: apt-get install go
+      - run: export GOPATH=$HOME/go
+      - run: export PATH=$PATH:$GOPATH/bin
 
       - checkout
       - run: make lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,20 @@ version: 2
 jobs:
   build:
     machine:
-        image: circleci/classic:201708-01
+      image: circleci/classic:201708-01
     steps:
-      - run: apt-get update
-      - run: apt-get install -y --no-install-recommends python3-pip python3-setuptools
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y --no-install-recommends python3-pip python3-setuptools
+      - run: pyenv global 3.5.2
       - run: pip3 install pylint pycodestyle
-      - run: apt-get install go
-      - run: export GOPATH=$HOME/go
-      - run: export PATH=$PATH:$GOPATH/bin
-
+      - run:
+          name: Install Golang
+          command: |
+            GO_VERSION="1.10.3"
+            GO_URL=https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz
+            curl $GO_URL | sudo tar -C /usr/local -x -z -f -
       - checkout
       - run: make lint
+      - run: make setup
+      - run: cp ./setup/cluster.json.example ./setup/cluster.json
+      - run: make all

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ DOCKER2ACI=$(BUILD_DIR)/docker2aci
 
 PYTHON3_FILES=$(shell find setup/ -type f | xargs awk '/python3/ {print FILENAME} {nextfile}')
 PYTHON3_DEPS:=pylint pycodestyle
-PYLINT3:=$(shell test -f /usr/local/bin/pylint && echo /usr/local/bin/pylint || echo $$HOME/.local/bin/pylint)
-PYCODESTYLE3:=$(shell test -f /usr/local/bin/pycodestyle && echo /usr/local/bin/pycodestyle || echo $$HOME/.local/bin/pycodestyle)
+PYLINT3:=$(shell which pylint || echo $$HOME/.local/bin/pylint)
+PYCODESTYLE3:=$(shell which pycodestyle || echo $$HOME/.local/bin/pycodestyle)
 
 BUILD_DEPS:=xorriso qemu-utils qemu-kvm ovmf curl ca-certificates cloud-image-utils gdisk kpartx python3-pip python3-setuptools
 CONTAINERS:=\


### PR DESCRIPTION
# [neco-ubuntu] make iso, make cloudもCIする

## 課題内容  
neco-ubuntuでmake isoやmake cloudのチェックをCIでしてない。  
CIでチェックして毎回ビルド可能かどうかチェックする。

## 設計
.circleci/config.ymlのチェック対象にイメージのビルド作業を追加  
※ dockerコンテナ上でのビルド → VM上でのビルドに  
( make cloud中のresize-and-copy-in-qcow2でパーティションをマウントしており、コンテナ実行ではその権限がないため、ビルドがこける可能性 )