### PR TITLE
Add commands to purge unattended-upgrades

### DIFF
--- a/patch/preseed/ubuntu-server.seed
+++ b/patch/preseed/ubuntu-server.seed
@@ -115,14 +115,12 @@ d-i finish-install/reboot_in_progress note
 d-i preseed/late_command string \
        mkdir -p /target/extras; \
        cp -a /cdrom/pool/extras/* /target/extras/; \
-       sed -i -e 's,http://us\.archive,http://archive,' /target/etc/apt/sources.list;
+       sed -i -e 's,http://us\.archive,http://archive,' /target/etc/apt/sources.list; \
+       in-target apt-get -y purge --auto-remove apport \
+         unattended-upgrades software-properties-common \
+         python3-software-properties ntpdate;
 
 #### ORIGINAL CONTENTS
-
-# Purge packages
-apt-get -y purge --auto-remove apport \
-    unattended-upgrades software-properties-common \
-    python3-software-properties ntpdate
 
 # Wait for two seconds in grub
 d-i	grub-installer/timeout	string 2

--- a/patch/preseed/ubuntu-server.seed
+++ b/patch/preseed/ubuntu-server.seed
@@ -118,7 +118,7 @@ d-i preseed/late_command string \
        sed -i -e 's,http://us\.archive,http://archive,' /target/etc/apt/sources.list; \
        in-target apt-get -y purge --auto-remove apport \
          unattended-upgrades software-properties-common \
-         python3-software-properties ntpdate;
+         python3-software-properties;
 
 #### ORIGINAL CONTENTS
 

--- a/patch/preseed/ubuntu-server.seed
+++ b/patch/preseed/ubuntu-server.seed
@@ -119,5 +119,10 @@ d-i preseed/late_command string \
 
 #### ORIGINAL CONTENTS
 
+# Purge packages
+apt-get -y purge --auto-remove apport \
+    unattended-upgrades software-properties-common \
+    python3-software-properties ntpdate
+
 # Wait for two seconds in grub
 d-i	grub-installer/timeout	string 2


### PR DESCRIPTION
As unattended-upgrades caused a race condition about `dpkg`, it is necessary to purge unattended-upgrades to make our `dctest` stable

This pull request made the following change.
1. purge unattended-upgrades in preseeds phase