### PR TITLE
[setup-route] Reboot when setup-route.service is failed

### DIFF
--- a/setup/setup-neco-network
+++ b/setup/setup-neco-network
@@ -235,6 +235,7 @@ After=network-online.target
 Type=oneshot
 ExecStart=/bin/ip route add 0.0.0.0/0 src {} nexthop via {} nexthop via {}
 RemainAfterExit=yes
+FailureAction=reboot-immediate
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Since it is a critical event, the machine should be rebooted
immediately when setup-route.service failed.