### PR TITLE
The release CI job uses quay.io/cybozu/golang:1.12-bionic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
             - cybozu-ubuntu-18.04-server-cloudimg-amd64.img
   release:
     docker:
-      - image: quay.io/cybozu/golang:1.10-bionic
+      - image: quay.io/cybozu/golang:1.12-bionic
     steps:
       - attach_workspace:
           at: ./artifacts


### PR DESCRIPTION
quay.io/cybozu/golang:1.10-bionic is no longer available.

Ref: https://circleci.com/gh/cybozu/neco-ubuntu/283